### PR TITLE
Consultancy #2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,11 @@ bods_url: ""
 graph:
   # The name of your graphic
   - title: "Graphic name"
+  # los tamaños minimos y maximos de los nodos (en pixeles, aproximativo)
   - sizes:
     - min: 10
     - max: 500
+  # colores de nodos y connectores
   - colours:
       - nodes:
           - default: '#1ee6d3'

--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -32,6 +32,10 @@
     }
 }
 
+.invisible-node {
+    opacity: 0;
+}
+
 @media (min-width: 992px) {
     .home-content {
         height: 100vh;

--- a/assets/javascript/towergraph.js
+++ b/assets/javascript/towergraph.js
@@ -472,6 +472,18 @@ function getOrganizations(params) {
 }
 */
 
+
+const mergeArray = a => Object.values(a.reduce((a, c) => {
+  o = a[c.id]
+
+  return Object.assign({}, a, {
+    [c.id]: o === undefined ? c : Object.assign({}, o, {
+      contracts_count: c.contracts_count + o.contracts_count,
+      contracts_amount: c.contracts_amount + o.contracts_amount,
+    })
+  })
+}, {}))
+
 function initGraph(data) {
   AppData.organizations = data.organizations.data;
   AppData.contracts = data.contracts.data;
@@ -480,7 +492,7 @@ function initGraph(data) {
 
   const contractsAmount = getContractsAmount(AppData.contracts);
   const contractsByTypes = getContractsByTypes(AppData.contracts);
-  const organizations = AppData.organizations;
+  const organizations = mergeArray(AppData.organizations);
   const investigations = AppData.investigations;
   const relatedFiguresStack = {};
   const slidesObjects = [

--- a/docs/C1/Seccion2.md
+++ b/docs/C1/Seccion2.md
@@ -41,10 +41,13 @@ Ahora comenzarás a darle forma a tu sitio, tendrás que definir un nombre para 
 
 	```
     graph:
+        # el nombre del grafico
         title: "Nombre del gráfico"
+        # los tamaños minimos y maximos de los nodos (en pixeles, aproximativo)
         sizes:
             - min: 5
             - max: 500
+        # colores de nodos y connectores
         colours:
              - nodes:
                  - default: '#1ee6d3'


### PR DESCRIPTION
** DONE contratos volando

En el gráfico de TowerBuilder hay algunas pelotitas que salen volando al pasar al slide 3 y en adelante. Estas pelotitas corresponden a contratos y proveedores. Aparentemente no se están creando de forma correcta los enlaces/edges entre estas y las otras por lo que no quedan vinculadas y son expulsadas por una de las fuerzas. 

there were various issues:
- the core problem was that nodes that represented contracts not connected to any organization should have not appeared and they did because of a css issue... but
- organizations were duplicated, introducing new nodes with the same ids, then the code would mix those duplicate ids with the contracts and all rendering went wuzwuz

we now correctly merge organizations and hide nodes that are marked as `invisible-node`

note that this PR is rebased on top of #3 that was lagging from Consultancy #1 
